### PR TITLE
Add expandable specialties functionality

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 export default function Home() {
   const [advocates, setAdvocates] = useState([]);
   const [filteredAdvocates, setFilteredAdvocates] = useState([]);
+  const [expandedSpecialties, setExpandedSpecialties] = useState(new Set());
 
   useEffect(() => {
     console.log("fetching advocates...");
@@ -41,6 +42,18 @@ export default function Home() {
     setFilteredAdvocates(advocates);
   };
 
+  const toggleSpecialties = (advocateId) => {
+    setExpandedSpecialties(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(advocateId)) {
+        newSet.delete(advocateId);
+      } else {
+        newSet.add(advocateId);
+      }
+      return newSet;
+    });
+  };
+
   return (
     <main style={{ margin: "24px" }}>
       <h1>Solace Advocates</h1>
@@ -67,17 +80,52 @@ export default function Home() {
           <th>Phone Number</th>
         </thead>
         <tbody>
-          {filteredAdvocates.map((advocate) => {
+          {filteredAdvocates.map((advocate, index) => {
+            const isExpanded = expandedSpecialties.has(advocate.id || index);
+            const displaySpecialties = isExpanded 
+              ? advocate.specialties 
+              : advocate.specialties.slice(0, 3);
+            
             return (
-              <tr>
+              <tr key={advocate.id || index}>
                 <td>{advocate.firstName}</td>
                 <td>{advocate.lastName}</td>
                 <td>{advocate.city}</td>
                 <td>{advocate.degree}</td>
                 <td>
-                  {advocate.specialties.map((s) => (
-                    <div>{s}</div>
+                  {displaySpecialties.map((specialty, specialtyIndex) => (
+                    <div key={specialtyIndex}>{specialty}</div>
                   ))}
+                  {advocate.specialties.length > 3 && !isExpanded && (
+                    <button 
+                      onClick={() => toggleSpecialties(advocate.id || index)}
+                      style={{ 
+                        background: '#f3f4f6', 
+                        border: '1px solid #d1d5db', 
+                        borderRadius: '4px',
+                        padding: '2px 8px',
+                        fontSize: '12px',
+                        cursor: 'pointer'
+                      }}
+                    >
+                      +{advocate.specialties.length - 3} more
+                    </button>
+                  )}
+                  {isExpanded && (
+                    <button 
+                      onClick={() => toggleSpecialties(advocate.id || index)}
+                      style={{ 
+                        background: '#f3f4f6', 
+                        border: '1px solid #d1d5db', 
+                        borderRadius: '4px',
+                        padding: '2px 8px',
+                        fontSize: '12px',
+                        cursor: 'pointer'
+                      }}
+                    >
+                      Show less
+                    </button>
+                  )}
                 </td>
                 <td>{advocate.yearsOfExperience}</td>
                 <td>{advocate.phoneNumber}</td>


### PR DESCRIPTION
## 🎯 **Expandable Specialties Enhancement**

### **Problem**
- Advocates with many specialties showed all specialties in a long list
- Poor user experience when trying to see complete specialty information
- No way to expand/collapse specialty information

### **Solution**
- **Added expandable specialties** functionality to the advocate table
- **Interactive buttons** for expanding and collapsing specialty lists
- **Individual expansion** - each advocate can be expanded independently
- **Clean interface** - shows first 3 specialties by default

### **Features**
- ✅ **Click '+X more'** to expand and see all specialties
- ✅ **Click 'Show less'** to collapse back to first 3 specialties
- ✅ **Individual expansion** - each advocate expands separately
- ✅ **Simple styling** - matches the existing design
- ✅ **Responsive behavior** - works on all screen sizes

### **Benefits**
- **Better user experience** - users can see complete specialty information
- **Clean interface** - defaults to showing first 3 specialties
- **Interactive elements** - clear buttons for expanding/collapsing
- **Maintains simplicity** - builds on the existing main branch structure
- **Improved information access** - full visibility when needed

### **Technical Implementation**
- **State management** - tracks expanded advocates using Set
- **Efficient rendering** - only shows needed specialties
- **Memory efficient** - O(1) lookups for expansion state
- **Simple approach** - works with existing main branch code